### PR TITLE
Feature/all vendors minified

### DIFF
--- a/src/themes/WordpressStandard/Configuration/Assets.php
+++ b/src/themes/WordpressStandard/Configuration/Assets.php
@@ -43,9 +43,6 @@ final class Assets extends BaseAssets
     public function productionAssets()
     {
         $this
-            ->addStylesheet('vendor', self::CSS)
-            ->addScript('vendor', self::BUILD_JS)
-
             ->addStylesheet('app.min', self::CSS)
             ->addScript('app.min', self::BUILD_JS);
     }

--- a/src/themes/WordpressStandard/gulpfile.js
+++ b/src/themes/WordpressStandard/gulpfile.js
@@ -86,7 +86,11 @@ gulp.task('sass', ['wp-style', 'scss-lint'], function () {
 });
 
 gulp.task('sass:prod', function () {
-  return gulp.src(paths.sass + '/app.scss')
+  return gulp.src([
+      paths.sass + '/app.scss'
+      // Put here css/scss vendor files, for example:
+      // paths.npm + '/slick-carousel/slick/slick.scss'
+    ])
     .pipe(plumber({
       errorHandler: onError
     }))
@@ -131,19 +135,6 @@ gulp.task('vendor-css', function () {
     .pipe(gulp.dest(paths.css));
 });
 
-gulp.task('vendor-js', function () {
-  return gulp.src([
-      paths.npm + '/jquery/dist/jquery.min.js',
-      paths.npm + '/fastclick/lib/fastclick.js',
-      paths.npm + '/svg4everybody/dist/svg4everybody.min.js'
-    ])
-    .pipe(plumber({
-      errorHandler: onError
-    }))
-    .pipe(concat('vendor.js'))
-    .pipe(gulp.dest(paths.buildJs));
-});
-
 gulp.task('modernizr', function () {
   return gulp.src([paths.js + '/*.js'])
     .pipe(plumber({
@@ -158,8 +149,15 @@ gulp.task('modernizr', function () {
     .pipe(gulp.dest(paths.buildJs))
 });
 
-gulp.task('js:prod', function () {
-  return gulp.src([paths.js + '/*.js'])
+gulp.task('js:prod', ['modernizr'], function () {
+  return gulp.src([
+      paths.buildJs + '/modernizr.js',
+      paths.npm + '/fastclick/lib/fastclick.js',
+      paths.npm + '/svg4everybody/dist/svg4everybody.min.js',
+      // Put here js vendor files, for example:
+      // paths.npm + '/slick-carousel/slick/slick.min.js'
+      paths.js + '/*.js'
+    ])
     .pipe(plumber({
       errorHandler: onError
     }))
@@ -176,4 +174,4 @@ gulp.task('watch', function () {
 
 gulp.task('default', ['sass', 'sprites', 'modernizr']);
 
-gulp.task('prod', ['sass:prod', 'js:prod', 'sprites', 'vendor-js', 'vendor-css', 'modernizr']);
+gulp.task('prod', ['sass:prod', 'sprites', 'modernizr', 'js:prod']);

--- a/src/themes/WordpressStandard/gulpfile.js
+++ b/src/themes/WordpressStandard/gulpfile.js
@@ -60,10 +60,10 @@ gulp.task('wp-style', function () {
 
 gulp.task('scss-lint', function () {
   return gulp.src([
-      watch.sass,
-      '!' + paths.sass + '/base/_reset.scss',
-      '!' + paths.sass + '/base/_grid.scss'
-    ])
+    watch.sass,
+    '!' + paths.sass + '/base/_reset.scss',
+    '!' + paths.sass + '/base/_grid.scss'
+  ])
     .pipe(plumber({
       errorHandler: onError
     }))
@@ -86,8 +86,6 @@ gulp.task('sass', ['wp-style', 'scss-lint'], function () {
 });
 
 gulp.task('sass:prod', function () {
-  // Import your css/scss vendor files in app.scss. Example:
-  // @import '../../../node_modules/slick-carousel/slick/slick.scss'
   return gulp.src(paths.sass + '/app.scss')
     .pipe(plumber({
       errorHandler: onError
@@ -137,13 +135,14 @@ gulp.task('modernizr', function () {
 
 gulp.task('js:prod', ['modernizr'], function () {
   return gulp.src([
-      paths.buildJs + '/modernizr.js',
-      paths.npm + '/fastclick/lib/fastclick.js',
-      paths.npm + '/svg4everybody/dist/svg4everybody.min.js',
-      // Put here js vendor files, for example:
-      // paths.npm + '/slick-carousel/slick/slick.min.js'
-      paths.js + '/*.js'
-    ])
+    paths.buildJs + '/modernizr.js',
+    paths.npm + '/fastclick/lib/fastclick.js',
+    paths.npm + '/svg4everybody/dist/svg4everybody.min.js',
+    paths.npm + '/picturefill/dist/picturefill.min.js',
+    // Put here js vendor files, for example:
+    // paths.npm + '/slick-carousel/slick/slick.min.js'
+    paths.js + '/*.js'
+  ])
     .pipe(plumber({
       errorHandler: onError
     }))

--- a/src/themes/WordpressStandard/gulpfile.js
+++ b/src/themes/WordpressStandard/gulpfile.js
@@ -123,18 +123,6 @@ gulp.task('sprites', function () {
     .pipe(gulp.dest(paths.buildSvg));
 });
 
-gulp.task('vendor-css', function () {
-  return gulp.src([
-      // Put here css files of vendors, for example:
-      // paths.npm + '/slick-carousel/slick/slick.css'
-    ])
-    .pipe(plumber({
-      errorHandler: onError
-    }))
-    .pipe(concat('vendor.css'))
-    .pipe(gulp.dest(paths.css));
-});
-
 gulp.task('modernizr', function () {
   return gulp.src([paths.js + '/*.js'])
     .pipe(plumber({

--- a/src/themes/WordpressStandard/gulpfile.js
+++ b/src/themes/WordpressStandard/gulpfile.js
@@ -86,11 +86,9 @@ gulp.task('sass', ['wp-style', 'scss-lint'], function () {
 });
 
 gulp.task('sass:prod', function () {
-  return gulp.src([
-      paths.sass + '/app.scss'
-      // Put here css/scss vendor files, for example:
-      // paths.npm + '/slick-carousel/slick/slick.scss'
-    ])
+  // Import your css/scss vendor files in app.scss. Example:
+  // @import '../../../node_modules/slick-carousel/slick/slick.scss'
+  return gulp.src(paths.sass + '/app.scss')
     .pipe(plumber({
       errorHandler: onError
     }))

--- a/src/themes/WordpressStandard/package.json
+++ b/src/themes/WordpressStandard/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "fastclick": "^1.0.6",
     "foundation-sites": "~6.2",
-    "jquery": "^2.2.1",
+    "picturefill": "^3.0.2",
     "svg4everybody": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Deleted vendor-css and vendor-js tasks and include all in a single minified file.
jQuery is not needed as WordPress inserts it as a mandatory dependency.
