### PR TITLE
Replaced scss-lint for stylelint v1

### DIFF
--- a/src/themes/WordpressStandard/Resources/assets/scss/base/_grid.scss
+++ b/src/themes/WordpressStandard/Resources/assets/scss/base/_grid.scss
@@ -133,11 +133,6 @@ $grid: (
   }
 }
 
-$my-color:#fff;
-.foo {
-  margin: 0;
-}
-
 @mixin grid__column($columns) {
   flex: 1 1 #{100% / $column-count * $columns};
   max-width: #{100% / $column-count * $columns};

--- a/src/themes/WordpressStandard/Resources/assets/scss/base/_grid.scss
+++ b/src/themes/WordpressStandard/Resources/assets/scss/base/_grid.scss
@@ -11,6 +11,7 @@
   @if length($range) <= 0 {
     @return 0;
   }
+
   @return nth($range, 1);
 }
 
@@ -18,6 +19,7 @@
   @if length($range) < 2 {
     @return 999999999999;
   }
+
   @return nth($range, 2);
 }
 
@@ -129,6 +131,11 @@ $grid: (
       @warn '#{$grid-type} not found in $grid map, check _grid-settings.scss';
     }
   }
+}
+
+$my-color:#fff;
+.foo {
+  margin: 0;
 }
 
 @mixin grid__column($columns) {

--- a/src/themes/WordpressStandard/gulpfile.js
+++ b/src/themes/WordpressStandard/gulpfile.js
@@ -24,7 +24,7 @@ var gulp = require('gulp'),
   postcss = require('gulp-postcss'),
   rename = require('gulp-rename'),
   sass = require('gulp-sass'),
-  scsslint = require('gulp-scss-lint'),
+  stylelint = require('gulp-stylelint'),
   svgSprite = require('gulp-svg-sprite'),
   uglify = require('gulp-uglify');
 
@@ -58,21 +58,28 @@ gulp.task('wp-style', function () {
   return file('style.css', content, {src: true}).pipe(gulp.dest('.'));
 });
 
-gulp.task('scss-lint', function () {
+gulp.task('stylelint', function () {
   return gulp.src([
-      watch.sass,
-      '!' + paths.sass + '/base/_reset.scss',
-      '!' + paths.sass + '/base/_grid.scss'
+      //watch.sass,
+      //'!' + paths.sass + '/base/_reset.scss',
+      //'!' + paths.sass + '/base/_grid.scss'
+      paths.sass + '/base/_grid.scss'
     ])
     .pipe(plumber({
       errorHandler: onError
     }))
-    .pipe(scsslint({
-      'config': './.scss_lint.yml'
+    .pipe(stylelint({
+      configFile: './stylelint/.stylelintrc',
+      failAfterError: false,
+      syntax: 'scss',
+      reporters: [{
+        formatter: 'string',
+        console: true
+      }]
     }));
 });
 
-gulp.task('sass', ['wp-style', 'scss-lint'], function () {
+gulp.task('sass', ['wp-style', 'stylelint'], function () {
   return gulp.src(paths.sass + '/app.scss')
     .pipe(plumber({
       errorHandler: onError

--- a/src/themes/WordpressStandard/gulpfile.js
+++ b/src/themes/WordpressStandard/gulpfile.js
@@ -60,10 +60,9 @@ gulp.task('wp-style', function () {
 
 gulp.task('stylelint', function () {
   return gulp.src([
-      //watch.sass,
-      //'!' + paths.sass + '/base/_reset.scss',
-      //'!' + paths.sass + '/base/_grid.scss'
-      paths.sass + '/base/_grid.scss'
+      watch.sass,
+      '!' + paths.sass + '/base/_reset.scss',
+      '!' + paths.sass + '/base/_grid.scss'
     ])
     .pipe(plumber({
       errorHandler: onError

--- a/src/themes/WordpressStandard/package.json
+++ b/src/themes/WordpressStandard/package.json
@@ -16,13 +16,21 @@
     "gulp-livereload": "^3.8.1",
     "gulp-modernizr": "0.0.0",
     "gulp-plumber": "^1.1.0",
-    "gulp-postcss": "^6.1.0",
+    "gulp-postcss": "^6.1.1",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.2.0",
-    "gulp-scss-lint": "^0.4.0",
+    "gulp-stylelint": "^2.0.2",
     "gulp-svg-sprite": "^1.2.19",
     "gulp-uglify": "^1.5.1",
-    "postcss-cssnext": "^2.4.0"
+    "postcss-cssnext": "^2.4.0",
+    "stylelint": "^6.5.1",
+    "stylelint-at-rule-import-path": "^1.0.2",
+    "stylelint-declaration-use-variable": "^1.3.0",
+    "stylelint-property-unknown": "^1.0.1",
+    "stylelint-scss": "^1.0.0",
+    "stylelint-selector-max-depth": "^0.1.3",
+    "stylelint-selector-no-mergeable": "^1.0.4",
+    "stylelint-value-border-zero": "^1.0.2"
   },
   "scripts": {
     "phoenix": "rm -rf node_modules && npm install"

--- a/src/themes/WordpressStandard/stylelint/.stylelintrc
+++ b/src/themes/WordpressStandard/stylelint/.stylelintrc
@@ -1,0 +1,134 @@
+{
+  "plugins": [
+    "./plugins/else-placement",
+    "stylelint-at-rule-import-path",
+    "stylelint-declaration-use-variable",
+    "stylelint-property-unknown",
+    "stylelint-scss",
+    "stylelint-selector-max-depth",
+    "stylelint-selector-no-mergeable",
+    "stylelint-value-border-zero"
+  ],
+  "rules": {
+    "at-rule-no-vendor-prefix": [true, {
+      "message": "Vendor prefixes are automatically generated (at-rule-no-vendor-prefix)"
+    }],
+    "at-rule-empty-line-before": ["always", {
+      except: ["blockless-group", "first-nested"],
+      ignore: ["after-comment"],
+    }],
+    "at-rule-import-path": [true, {
+      allowUnderscore: [false],
+      allowExtension: [false]
+    }],
+    "at-rule-name-case": "lower",
+    "at-rule-name-space-after": "always-single-line",
+    "at-rule-semicolon-newline-after": "always",
+    "block-closing-brace-newline-after": ["always", {
+      ignoreAtRules: ["if", "else"]
+    }],
+    "block-closing-brace-newline-before": "always-multi-line",
+    "block-closing-brace-space-before": "always-single-line",
+    "block-no-empty": true,
+    "block-opening-brace-newline-after": "always-multi-line",
+    "block-opening-brace-space-after": "always-single-line",
+    "block-opening-brace-space-before": "always",
+    "color-hex-case": ["lower", {
+      "severity": "warning",
+      "message": "Lowercase letters in hex code are more distinct (color-hex-case)"
+    }],
+    "color-hex-length": ["short", {
+      "severity": "warning",
+      "message": "Keep all hex code values at a standardized six character length (color-hex-length)"
+    }],
+    "color-named": ["never", {
+      "severity": "warning",
+      "message": "Browsers can render named colors inconsistently, use variables instead (color-named)"
+    }],
+    "color-no-invalid-hex": true,
+    "declaration-bang-space-after": "never",
+    "declaration-bang-space-before": "always",
+    "declaration-colon-newline-after": "always-multi-line",
+    "declaration-colon-space-after": "always-single-line",
+    "declaration-colon-space-before": "never",
+    "declaration-block-properties-order": "alphabetical",
+    "declaration-block-trailing-semicolon": "always",
+    "declaration-block-no-duplicate-properties": true,
+    "declaration-block-no-shorthand-property-overrides": true,
+    "declaration-block-semicolon-newline-after": "always-multi-line",
+    "declaration-block-semicolon-space-after": "always-single-line",
+    "declaration-block-semicolon-space-before": "never",
+    "declaration-block-single-line-max-declarations": [1, {
+        "severity": "warning"
+    }],
+    "declaration-no-important": true,
+    "declaration-use-variable": "color",
+    "font-family-name-quotes": "single-where-required",
+    "function-calc-no-unspaced-operator": true,
+    "function-comma-space-after": "always-single-line",
+    "function-comma-space-before": "never-single-line",
+    "function-linear-gradient-no-nonstandard-direction": true,
+    "function-parentheses-newline-inside": "always-multi-line",
+    "function-parentheses-space-inside": "never-single-line",
+    "function-url-quotes": "single",
+    "function-whitespace-after": "always",
+    "indentation": 2,
+    "max-nesting-depth": [2, {
+      "ignore": ["at-rules-without-declaration-blocks"]
+    }],
+    "media-feature-colon-space-after": "always",
+    "media-feature-colon-space-before": "never",
+    "media-feature-name-no-vendor-prefix": [true, {
+        "message": "Vendor prefixes are automatically generated (media-feature-name-no-vendor-prefix)"
+    }],
+    "media-feature-no-missing-punctuation": true,
+    "media-feature-range-operator-space-after": "always",
+    "media-feature-range-operator-space-before": "always",
+    "media-query-parentheses-space-inside": "never",
+    "media-query-list-comma-newline-after": "always-multi-line",
+    "media-query-list-comma-newline-before": "never-multi-line",
+    "no-duplicate-selectors": true,
+    "no-eol-whitespace": true,
+    "no-missing-eof-newline": [true, {
+      "message": "Files should end with a trailing newline (no-missing-eof-newline)"
+    }],
+    "no-unknown-animations": true,
+    "number-leading-zero": "never",
+    "number-no-trailing-zeros": true,
+    "number-zero-length-no-unit": true,
+    "plugin/else-placement": "same-line",
+    "property-unknown": true,
+    "property-no-vendor-prefix": [true, {
+      "message": "Vendor prefixes are automatically generated (property-no-vendor-prefix)"
+    }],
+    "rule-nested-empty-line-before": ["always-multi-line", {
+        except: ["first-nested"]
+    }],
+    "rule-non-nested-empty-line-before": "always",
+    "scss/at-extend-no-missing-placeholder": true,
+    "scss/selector-no-redundant-nesting-selector": true,
+    "selector-list-comma-newline-after": "always",
+    "selector-list-comma-space-after": "always-single-line",
+    "selector-list-comma-space-before": "never",
+    "selector-max-depth": 3,
+    "selector-no-id": true,
+    "selector-no-mergeable": [true, { "allowVanityNesting": true }],
+    "selector-no-qualifying-type": true,
+    "selector-no-vendor-prefix": [true, {
+      "message": "Vendor prefixes are automatically generated (selector-no-vendor-prefix)"
+    }],
+    "selector-pseudo-class-no-unknown": true,
+    "selector-pseudo-element-no-unknown": true,
+    "selector-type-no-unknown": true,
+    "shorthand-property-no-redundant-values": true,
+    "string-quotes": "single",
+    "value-border-zero": {
+      "convention": "0"
+    },
+    "value-list-comma-space-after": "always-single-line",
+    "value-list-comma-space-before": "never-single-line",
+    "value-no-vendor-prefix": [true, {
+      "message": "Vendor prefixes are automatically generated (value-no-vendor-prefix)"
+    }]
+  }
+}

--- a/src/themes/WordpressStandard/stylelint/plugins/else-placement/index.js
+++ b/src/themes/WordpressStandard/stylelint/plugins/else-placement/index.js
@@ -1,0 +1,56 @@
+var stylelint = require('stylelint');
+var utils = stylelint.utils;
+
+var ruleName = 'plugin/else-placement';
+var messages = utils.ruleMessages(ruleName, {
+  rejectedSameLine: '@else should be on the same line as the preceding \}',
+  rejectedNextLine: '@else should be on a new line after the preceding \}'
+});
+
+function hasNewLine(string) {
+  return /[\r\n]/.test(string);
+}
+
+var pluginDefinition = stylelint.createPlugin(ruleName, function(enabled, options) {
+  return function(css, result) {
+    var validOptions = utils.validateOptions(result, ruleName, {
+      actual: enabled,
+      possible: ['same-line', 'next-line']
+    });
+
+    if (!validOptions) {
+      return;
+    }
+
+    css.walkAtRules(function(statement) {
+      var raw = statement.raws;
+
+      // ignore everything but an else statement
+      if (statement.name !== 'else') {
+        return;
+      }
+
+      if (enabled === 'same-line' && hasNewLine(raw.before)) {
+        utils.report({
+          node: statement,
+          message: messages.rejectedSameLine,
+          result: result,
+          ruleName: ruleName
+        });
+      }
+
+      if (enabled === 'next-line' && !hasNewLine(raw.before)) {
+        utils.report({
+          node: statement,
+          message: messages.rejectedNextLine,
+          result: result,
+          ruleName: ruleName
+        });
+      }
+    });
+  }
+});
+
+module.exports = pluginDefinition;
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;


### PR DESCRIPTION
This is WIP. Some features are not working:
- [ ] BemDepth: { enabled: false, max_elements: 1 }
- [ ] Comment: { enabled: true }
- [ ] NameFormat: { enabled: true, allow_leading_underscore: true, convention: hyphenated_lowercase, mixin_convention: '^([.\%]?[a-z]_[-]?[a-z0-9-]_)(.[a-z0-9-]_)?(__[a-z0-9]_[-]?[a-z0-9-]_)?(--[a-z0-9]_[-]?[a-z0-9-]_)?(:[a-z]_)_$', mixin_convention_explanation: 'BEM pattern', placeholder_convention: '^([.\%]?[a-z]_[-]?[a-z0-9-]_)(.[a-z0-9-]_)?(__[a-z0-9]_[-]?[a-z0-9-]_)?(--[a-z0-9]_[-]?[a-z0-9-]_)?(:[a-z]_)_$', placeholder_convention_explanation: 'BEM pattern' }
- [ ] SelectorFormat: { enabled: true, convention: hyphenated_BEM }
- [ ] SpaceAfterVariableName: { enabled: true }
- [ ] SpaceAroundOperator: { enabled: true, style: one_space }
- [ ] UrlFormat: { enabled: true }

Also, there are new features to check:
- [ ] Stylelint new features check ([here all](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/rules.md) and [here a boilerplate](https://github.com/ericwbailey/boilerplate/blob/master/.stylelintrc))
