### PR TITLE
Escape user and password on mysqldump command in deploy.rb

### DIFF
--- a/deploy/deploy.rb
+++ b/deploy/deploy.rb
@@ -152,7 +152,7 @@ namespace :database do
         end
       end
       if dbuser != nil and dbpass != nil and dbname != nil
-        execute "cd #{shared_path};mysqldump -u#{dbuser} -p#{dbpass} #{dbname} > #{dbname}_cap.sql"
+        execute "cd #{shared_path};mysqldump -u'#{dbuser}' -p'#{dbpass}' #{dbname} > #{dbname}_cap.sql"
         download! "#{shared_path}/#{dbname}_cap.sql", "."
         execute :rm, "-f", "#{shared_path}/#{dbname}_cap.sql"
       else


### PR DESCRIPTION
 In `database:download` task we had issues with a password with '|' character, this fixes it
