### PR TITLE
Run clear cache command on deploy locally

### DIFF
--- a/deploy/tasks/cache_clear.cap
+++ b/deploy/tasks/cache_clear.cap
@@ -12,7 +12,7 @@
 namespace :cache do
   desc 'Clears accelerator caches'
   task :clear do
-    on roles(:all) do |host|
+    run_locally do
       execute "curl #{fetch(:cache_opts)} #{fetch(:domain)}/scripts/clearcache.php"
     end
   end


### PR DESCRIPTION
 Avoids authorization issues in development environments
